### PR TITLE
feat(PC-4150): Add new celery metric

### DIFF
--- a/src/exporter.py
+++ b/src/exporter.py
@@ -17,6 +17,11 @@ from prometheus_client import CollectorRegistry, Counter, Gauge, Histogram
 
 from .http_server import start_http_server
 
+TASK_RUNTIME_V2_BUCKETS = (
+    0.1, 0.5, 1, 2, 5, 10, 30, 60, 120, 300, 600,
+    1200, 1800, 2700, 3600, 5400, 7200, 10800, 14400,
+)
+
 
 class Exporter:  # pylint: disable=too-many-instance-attributes,too-many-branches
     state: State = None
@@ -123,6 +128,13 @@ class Exporter:  # pylint: disable=too-many-instance-attributes,too-many-branche
             registry=self.registry,
             buckets=buckets or Histogram.DEFAULT_BUCKETS,
         )
+        self.celery_task_runtime_v2 = Histogram(
+            f"{metric_prefix}task_runtime_v2_seconds",
+            "Histogram of task runtime measurements with extended buckets for long-running tasks (seconds).",
+            ["name", "hostname", "queue_name", *self.static_label_keys],
+            registry=self.registry,
+            buckets=TASK_RUNTIME_V2_BUCKETS,
+        )
         self.celery_queue_length = Gauge(
             f"{metric_prefix}queue_length",
             "The number of message in broker queue.",
@@ -194,6 +206,10 @@ class Exporter:  # pylint: disable=too-many-instance-attributes,too-many-branche
         for label_seq in list(self.celery_task_runtime._metrics.keys()):
             if hostname in label_seq:
                 self.celery_task_runtime.remove(*label_seq)
+
+        for label_seq in list(self.celery_task_runtime_v2._metrics.keys()):
+            if hostname in label_seq:
+                self.celery_task_runtime_v2.remove(*label_seq)
 
         del self.worker_last_seen[hostname]
 
@@ -314,6 +330,13 @@ class Exporter:  # pylint: disable=too-many-instance-attributes,too-many-branche
             logger.debug(
                 "Observed metric='{}' labels='{}': {}s",
                 self.celery_task_runtime._name,
+                labels,
+                task.runtime,
+            )
+            self.celery_task_runtime_v2.labels(**labels).observe(task.runtime)
+            logger.debug(
+                "Observed metric='{}' labels='{}': {}s",
+                self.celery_task_runtime_v2._name,
                 labels,
                 task.runtime,
             )

--- a/src/help.py
+++ b/src/help.py
@@ -50,6 +50,7 @@ for metric in [
     temp_exporter.celery_worker_up,
     temp_exporter.worker_tasks_active,
     temp_exporter.celery_task_runtime,
+    temp_exporter.celery_task_runtime_v2,
 ]:
     cmd_help += f"""
 \b

--- a/src/test_cli.py
+++ b/src/test_cli.py
@@ -108,6 +108,10 @@ def test_integration(broker, celery_app, threaded_exporter, hostname):
         f'celery_task_runtime_count{{hostname="{hostname}",name="src.test_cli.succeed",queue_name="celery"}} 2.0'
         in res.text
     )
+    assert (
+        f'celery_task_runtime_v2_seconds_count{{hostname="{hostname}",name="src.test_cli.succeed",queue_name="celery"}} 2.0'
+        in res.text
+    )
     assert 'celery_queue_length{queue_name="celery"} 0.0' in res.text
 
     # TODO: Fix this...
@@ -267,6 +271,10 @@ def test_integration_static_labels(
     )
     assert (
         f'celery_task_runtime_count{{hostname="{hostname}",name="src.test_cli.succeed",queue_name="celery",{static_labels_str}}} 2.0'
+        in res.text
+    )
+    assert (
+        f'celery_task_runtime_v2_seconds_count{{hostname="{hostname}",name="src.test_cli.succeed",queue_name="celery",{static_labels_str}}} 2.0'
         in res.text
     )
     assert (


### PR DESCRIPTION
Create new histogram metric for more detailed bucket allocations up to 4 hours for enhanced debugging capabilities. 
https://emburse.atlassian.net/browse/PC-4150

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive Prometheus metrics only; same label cardinality as the existing runtime histogram, with no changes to task execution or broker behavior.
> 
> **Overview**
> Adds a **second** task runtime Prometheus histogram, `celery_task_runtime_v2_seconds`, alongside the existing `celery_task_runtime` metric. The original histogram and its configurable buckets are **unchanged**; the new series uses fixed `TASK_RUNTIME_V2_BUCKETS` from **0.1s through 4 hours** (14,400s) for finer visibility on long-running Celery tasks.
> 
> On each `task-succeeded` event, runtimes are observed into **both** histograms with the same labels (`name`, `hostname`, `queue_name`, static labels). Offline worker purge now also removes `celery_task_runtime_v2` series. CLI help and integration tests assert the new metric is exposed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 266af19e41ab41b65ef7d47684da093f064a99f4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->