### PR TITLE
[PC-4150]: add new runtime metric poetry update

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     name: Build image
     outputs:
       image_tag: ${{ env.commit_sha }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   build:
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     name: Build image
     outputs:
       image_tag: ${{ env.commit_sha }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,11 +20,9 @@ jobs:
           python-version: 3.13
 
       - name: Install Poetry
-        uses: snok/install-poetry@v1
+        uses: abatilo/actions-poetry@v3
         with:
-          virtualenvs-create: true
-          virtualenvs-in-project: true
-          installer-parallel: true
+          poetry-version: latest
 
       - name: Load cached venv
         id: cached-poetry-dependencies
@@ -75,11 +73,9 @@ jobs:
           python-version: 3.13
 
       - name: Install Poetry
-        uses: snok/install-poetry@v1
+        uses: abatilo/actions-poetry@v3
         with:
-          virtualenvs-create: true
-          virtualenvs-in-project: true
-          installer-parallel: true
+          poetry-version: latest
 
       - name: Load cached venv
         id: cached-poetry-dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,12 @@ jobs:
       - name: Install Poetry
         uses: abatilo/actions-poetry@v3
         with:
-          poetry-version: latest
+          poetry-version: "1.8.4"
+
+      - name: Configure Poetry virtualenv
+        run: |
+          poetry config virtualenvs.create true --local
+          poetry config virtualenvs.in-project true --local
 
       - name: Load cached venv
         id: cached-poetry-dependencies
@@ -75,7 +80,12 @@ jobs:
       - name: Install Poetry
         uses: abatilo/actions-poetry@v3
         with:
-          poetry-version: latest
+          poetry-version: "1.8.4"
+
+      - name: Configure Poetry virtualenv
+        run: |
+          poetry config virtualenvs.create true --local
+          poetry config virtualenvs.in-project true --local
 
       - name: Load cached venv
         id: cached-poetry-dependencies

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,6 @@ classifiers = [
 ]
 
 [tool.black]
-skip_numeric_underscore_normalization = true
 exclude = ".*(venv|virtualenv|.poetry|migrations|node_modules)"
 
 [tool.isort]

--- a/src/exporter.py
+++ b/src/exporter.py
@@ -18,8 +18,25 @@ from prometheus_client import CollectorRegistry, Counter, Gauge, Histogram
 from .http_server import start_http_server
 
 TASK_RUNTIME_V2_BUCKETS = (
-    0.1, 0.5, 1, 2, 5, 10, 30, 60, 120, 300, 600,
-    1200, 1800, 2700, 3600, 5400, 7200, 10800, 14400,
+    0.1,
+    0.5,
+    1,
+    2,
+    5,
+    10,
+    30,
+    60,
+    120,
+    300,
+    600,
+    1200,
+    1800,
+    2700,
+    3600,
+    5400,
+    7200,
+    10800,
+    14400,
 )
 
 

--- a/src/exporter.py
+++ b/src/exporter.py
@@ -147,6 +147,7 @@ class Exporter:  # pylint: disable=too-many-instance-attributes,too-many-branche
         )
         self.celery_task_runtime_v2 = Histogram(
             f"{metric_prefix}task_runtime_v2_seconds",
+            # pylint: disable=line-too-long
             "Histogram of task runtime measurements with extended buckets for long-running tasks (seconds).",
             ["name", "hostname", "queue_name", *self.static_label_keys],
             registry=self.registry,

--- a/src/test_cli.py
+++ b/src/test_cli.py
@@ -7,6 +7,7 @@ from requests.exceptions import HTTPError
 
 
 @pytest.mark.celery()
+# pylint: disable=too-many-statements
 def test_integration(broker, celery_app, threaded_exporter, hostname):
     exporter_url = f"http://localhost:{threaded_exporter.cfg['port']}/metrics"
 


### PR DESCRIPTION
Looking to get the pipeline working to get a new build version to attach to CGW. Updating to use actions-poetry as its already on the allowlist.

https://emburse.slack.com/archives/C06T2PXUP/p1780334094806879?thread_ts=1780322406.150049&cid=C06T2PXUP


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only CI Poetry setup, formatter config, and pylint/format tweaks—no runtime behavior or security-sensitive logic changes in the diff.
> 
> **Overview**
> Updates **GitHub Actions** so **lint** and **test** jobs install Poetry via `abatilo/actions-poetry@v3` at **1.8.4** instead of `snok/install-poetry`, with virtualenv creation/in-project paths set through explicit `poetry config` steps (same `.venv` cache behavior).
> 
> **Tooling-only** edits elsewhere: drops a deprecated Black option from `pyproject.toml`, reformats `TASK_RUNTIME_V2_BUCKETS` and adds a pylint line-length waiver in `exporter.py`, and silences `too-many-statements` on the main integration test in `test_cli.py`. No change to how runtime metrics are recorded beyond style/lint.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7b6f03f8dda95750e60518dc896ffb084057e067. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->